### PR TITLE
Added kogpt playground demo

### DIFF
--- a/demo/gpt_playground/model_api/kogpt_api.py
+++ b/demo/gpt_playground/model_api/kogpt_api.py
@@ -13,10 +13,13 @@ bos_token='[BOS]', eos_token='[EOS]', unk_token='[UNK]', pad_token='[PAD]', mask
 )
 
 model = AutoModelForCausalLM.from_pretrained(
-'kakaobrain/kogpt', revision='KoGPT6B-ryan1.5b-float16',  # or float32 version: revision=KoGPT6B-ryan1.5b
-pad_token_id=tokenizer.eos_token_id,
-torch_dtype='auto', low_cpu_mem_usage=True,
-device_map="auto", load_in_8bit=True,
+                                                                                                    'kakaobrain/kogpt',
+                                                                                                    revision='KoGPT6B-ryan1.5b-float16',  # or float32 version: revision=KoGPT6B-ryan1.5b
+                                                                                                    pad_token_id=tokenizer.eos_token_id,
+                                                                                                    torch_dtype=torch.float16,
+                                                                                                    low_cpu_mem_usage=True,
+                                                                                                    device_map="auto",
+                                                                                                    load_in_8bit=False,
 )
 model.eval()
 

--- a/demo/gpt_playground/model_api/model_api.py
+++ b/demo/gpt_playground/model_api/model_api.py
@@ -1,0 +1,88 @@
+import torch
+import copy
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from typing import List
+import requests
+import json
+
+tokenizer = AutoTokenizer.from_pretrained(
+'kakaobrain/kogpt', revision='KoGPT6B-ryan1.5b-float16',  # or float32 version: revision=KoGPT6B-ryan1.5b
+bos_token='[BOS]', eos_token='[EOS]', unk_token='[UNK]', pad_token='[PAD]', mask_token='[MASK]'
+)
+
+model = AutoModelForCausalLM.from_pretrained(
+'kakaobrain/kogpt', revision='KoGPT6B-ryan1.5b-float16',  # or float32 version: revision=KoGPT6B-ryan1.5b
+pad_token_id=tokenizer.eos_token_id,
+torch_dtype='auto', low_cpu_mem_usage=True,
+device_map="auto", load_in_8bit=True,
+)
+model.eval()
+
+def generate(text, max_new_tokens,  num_sequences, do_sample, top_k, top_p, temperature):
+    tokenized_text = tokenizer(text, return_tensors='pt').to('cuda')
+    with torch.no_grad():
+        try:
+            generated_ids = model.generate(
+                tokenized_text.input_ids,
+                do_sample=do_sample, #샘플링 전략 사용
+                max_new_tokens= max_new_tokens, # 최대 디코딩 길이
+                top_k=top_k, # 확률 순위 밖인 토큰은 샘플링에서 제외
+                top_p=top_p, # 누적 확률 이내의 후보집합에서만 생성
+                temperature=temperature,
+                no_repeat_ngram_size = 4,
+                num_return_sequences = num_sequences # 한 번에 출력할 다음 문장 선택지의 개수
+            )
+        except:
+            generated_ids = [''] * num_sequences
+            torch.cuda.empty_cache()
+    torch.cuda.empty_cache()
+    generated_texts = [tokenizer.decode(id, skip_special_tokens=True) for id in generated_ids]
+    new_sentences = [sent.split(text)[-1] for sent in generated_texts]
+    return new_sentences
+
+app = FastAPI(title='kogpt',
+              description='kakaobrain-kogpt6B-fp16',
+              version="1.0")
+
+
+class textInput(BaseModel):
+    """Input model for prediction
+    """
+    text: str = Field(None, description='Prompt', example="여기에 입력")
+    max_new_tokens: int = Field(64, description='Maximum length of generated sequence')
+    num_sequences: int = Field(1, description="Number of sequences to generate")
+    do_sample: bool = Field(True, description="Use sampling for generation")
+    top_k: int = Field(0, description="Top K for generation")
+    top_p: float = Field(0.8, description="Top P for generation")
+    temperature:float = Field(0.19, description="Temperature for generation") 
+    
+
+class textResponse(BaseModel):
+    prompt: str = Field(None, description="Original prompt for generation")
+    generated: List[str] = Field(None, description="generated texts")
+    num_sequences: int = Field(None, description="Number of generated sequences")
+
+
+@app.get("/")
+def home():
+    return "Refer to '/docs' for API documentation"
+
+
+@app.post("/generate", description="Generation", response_model=textResponse)
+def get_generation(req_body: textInput):
+    """Prediction
+    :param req_body:
+    :return:
+    """
+    torch.cuda.empty_cache()
+    result = generate(req_body.text,
+                      req_body.max_new_tokens,
+                      req_body.num_sequences,
+                      req_body.do_sample,
+                      req_body.top_k,
+                      req_body.top_p,
+                      req_body.temperature,
+                    )
+    return {"prompt": req_body.text, "generated":result, "num_sequences":req_body.num_sequences}

--- a/demo/gpt_playground/streamlit_app.py
+++ b/demo/gpt_playground/streamlit_app.py
@@ -1,0 +1,78 @@
+"""
+## App: NLP App with Streamlit (NLPiffy)
+Author: [Seongjin Lee(GirinMan)](https://github.com/GirinMan))\n
+Source: [Github](https://github.com/GirinMan/HAI-DialectTranslator/)
+Credits: 2022-Fall HAI Team 1 project
+
+실행 방법: streamlit run app.py
+
+
+"""
+# Core Pkgs
+import streamlit as st 
+import requests
+import json
+
+SPAWNER_API = "API LINK"
+headers = {'content-type': 'application/json'}
+
+st.set_page_config(layout="wide")
+
+def main():
+    """ NLP Based App with Streamlit """
+    
+    # Title
+    st.title("HAI-ground")
+    st.markdown("https://github.com/HanyangTechAI/HAI-ground")
+    st.markdown("""
+        #### Description
+        - 입력된 문장에 이어지는 다음 텍스트를 자동으로 생성해 줍니다.
+        - GPT-3 모델에 대한 자세한 설명은 [링크](https://openai.com/blog/gpt-3-apps)를 참고하세요.
+        - Powered by [KoGPT](https://huggingface.co/kakaobrain/kogpt)(KakaoBrain)
+        """)
+    
+    with st.sidebar:
+        st.title("Advanced options")
+        max_new_tokens = st.number_input('Max new tokens', min_value=1, max_value=2048, value=32)
+        do_sample = st.checkbox('Use sampling', value=True)
+        if do_sample:
+            num_output = st.number_input('Number of outputs', min_value=1, max_value=5, value=1)
+            top_p = st.slider('Top P', min_value=0., max_value=1., value=0.8)
+            top_k = st.slider('Top K', min_value=0, value=0) 
+            temperature = st.slider('Temperature', min_value=0., max_value=2., value=0.19)
+        else:
+             num_output = 1
+             top_p = 0
+             top_k = 0.
+             temperature = 0.
+
+
+    input_area = st.empty()
+    input_area.text_area(f"텍스트 입력", "여기에 입력", key='input_txt' ,height=200)
+
+    area = st.container()
+
+    if st.button("Submit"):
+
+        area.subheader("문장 생성 결과")
+        input_txt = st.session_state.input_txt
+
+        with area:
+            with st.spinner("Generating next sentences..."):
+                body = json.dumps({
+                    "text": input_txt,
+                    "num_sequences":num_output,
+                    "max_new_tokens":max_new_tokens,
+                    "do_sample":do_sample,
+                    "top_k":top_k,
+                    "top_p":top_p,
+                    "temperature":temperature,
+                })
+                response = requests.post(url=SPAWNER_API+'generate', headers=headers, data=body).json()
+                new_sentences = response["generated"]
+
+        for i, sent in enumerate(new_sentences):
+            area.text_area(f'Result {i+1}', sent)
+
+if __name__ == '__main__':
+	main()

--- a/demo/gpt_playground/streamlit_app.py
+++ b/demo/gpt_playground/streamlit_app.py
@@ -50,29 +50,26 @@ def main():
     input_area = st.empty()
     input_area.text_area(f"텍스트 입력", "여기에 입력", key='input_txt' ,height=200)
 
-    area = st.container()
-
     if st.button("Submit"):
 
-        area.subheader("문장 생성 결과")
+        st.subheader("문장 생성 결과")
         input_txt = st.session_state.input_txt
 
-        with area:
-            with st.spinner("Generating next sentences..."):
-                body = json.dumps({
-                    "text": input_txt,
-                    "num_sequences":num_output,
-                    "max_new_tokens":max_new_tokens,
-                    "do_sample":do_sample,
-                    "top_k":top_k,
-                    "top_p":top_p,
-                    "temperature":temperature,
-                })
-                response = requests.post(url=SPAWNER_API+'generate', headers=headers, data=body).json()
-                new_sentences = response["generated"]
+        with st.spinner("Generating next sentences..."):
+            body = json.dumps({
+                "text": input_txt,
+                "num_sequences":num_output,
+                "max_new_tokens":max_new_tokens,
+                "do_sample":do_sample,
+                "top_k":top_k,
+                "top_p":top_p,
+                "temperature":temperature,
+            })
+            response = requests.post(url=SPAWNER_API+'generate', headers=headers, data=body).json()
+            new_sentences = response["generated"]
 
         for i, sent in enumerate(new_sentences):
-            area.text_area(f'Result {i+1}', sent)
+            st.text_area(f'Result {i+1}', sent)
 
 if __name__ == '__main__':
 	main()


### PR DESCRIPTION
### KoGPT playground demo 업데이트
- #2
- kakaobrain/kogpt 모델 체크포인트 8bit-quantization 적용하여 서빙
메모리 사용량 fp32기준 24GB -> 약 7.4GB로 절약됨(inference 속도는 크게 차이 없는 듯)
- 모델 호출용 API와 streamlit app page를 별도로 구분하여 개발함
- 데모 실행 링크: http://HAI-ground.online (서버가 꺼져있으면 실행 안 될수도)

@Thxios @hyunwoo3235
학술부 친구들은 코드 어떤 식으로 구현했는지 간단하게 리뷰 부탁해요.
크게 streamlit으로 구현한 FE 앱 부분과 FASTAPI를 활용해서 모델 서빙하는 부분으로 나눠져 있어요.
테스트를 위해 API 링크가 필요하면 카톡으로 알려드리겠습니다.